### PR TITLE
Fix counting for 'else' and 'elif'

### DIFF
--- a/tests/test_cognitive_complexity.py
+++ b/tests/test_cognitive_complexity.py
@@ -46,6 +46,28 @@ def test_simple_structure_condition_complexity():
     """) == 2
 
 
+def test_simple_elif_condition_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a, b):
+        if (a):  # +1
+            return 1
+        elif (b):  # +1
+            return 2
+        else:  # +1
+            return 3
+    """) == 3
+
+
+def test_simple_else_condition_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a):
+        if (a):  # +1
+            return 1
+        else:  # +1
+            return 3
+    """) == 2
+
+
 def test_nested_structure_condition_complexity():
     assert get_code_snippet_compexity("""
     def f(a, b):
@@ -97,10 +119,10 @@ def test_real_function():
             ):
                 if is_camel_case_word(word):  # +2
                     raw_camelcase_words.append(word)
-                else:
+                else:  # +1
                     processed_words.append(word.lower())
         return processed_words, raw_camelcase_words
-    """) == 10
+    """) == 11
 
 
 def test_break_and_continue():
@@ -132,3 +154,67 @@ def test_ternary_operator():
             return 'c' if a else 'd'  # +2
         return 'a' if a else 'b'  # +1
     """) == 4
+
+
+def test_nested_if_condition_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a, b):
+        if a == b:  # +1
+            if (a):  # +2 (nesting=1)
+                return 1
+        return 0
+    """) == 3
+
+
+def test_nested_else_condition_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a, b):
+        if a == b:  # +1
+            if (a):  # +2 (nesting=1)
+                return 1
+            else:  # +1
+                return 3
+        return 0
+    """) == 4
+
+
+def test_nested_elif_condition_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a, b):
+        if a == b:  # +1
+            if (a):  # +2 (nesting=1)
+                return 1
+            elif (b):  # +1
+                return 2
+            else:  # +1
+                return 3
+        return 0
+    """) == 5
+
+
+def test_for_else_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a):
+        for a in range(10):  # +1
+            if a % 2:  # +2
+                continue  # +2
+            if a == 8:  # +2
+                break  # +2
+        else:  # +1
+            return 5
+    """) == 10
+
+
+def test_while_else_complexity():
+    assert get_code_snippet_compexity("""
+    def f(a):
+        a = 0
+        while a < 10:  # +1
+            if a % 2:  # +2
+                continue  # +2
+            if a == 8:  # +2
+                break  # +2
+            a += 1
+        else:  # +1
+            return 5
+    """) == 10


### PR DESCRIPTION
Per the Cognitive Complexity specification, the `else` and `elif` keywords should get an increment but not a nesting increment. But `ast.iter_child_nodes()` does not yield the `orelse` itself, only its children.

Therefore, extend `process_node_itself` to improve the counting:

- An `ast.IfExp` is treated as a ternary. It already gets an increment for the node, and does not get another increment for the `orelse`.
- In an `ast.If` node, if the `orelse` contains only a single `ast.If` then the `orelse` part is actually an `else if` or `elif`. The child `ast.If` already gets an increment and nesting level, but nothing should be done for the `else` itself (not even a nesting level).
- Any other `else` causes an increment, as well as a nesting level.
- If/For/While without an else are treated as before.

Closes #11. 