### PR TITLE
Fix counting for binary logical operators

### DIFF
--- a/cognitive_complexity/utils/ast.py
+++ b/cognitive_complexity/utils/ast.py
@@ -85,7 +85,7 @@ def process_node_itself(
         return increment_by, 0, True
     elif isinstance(node, ast.BoolOp):
         inner_boolops_amount = len([n for n in ast.walk(node) if isinstance(n, ast.BoolOp)])
-        base_complexity = inner_boolops_amount * max(increment_by, 1)
+        base_complexity = inner_boolops_amount
         return increment_by, base_complexity, False
     elif isinstance(node, (ast.Break, ast.Continue)):
         return increment_by, max(1, increment_by), True

--- a/tests/test_cognitive_complexity.py
+++ b/tests/test_cognitive_complexity.py
@@ -113,16 +113,16 @@ def test_real_function():
         raw_camelcase_words = []
         for raw_word in re.findall(r'[a-z]+', constant):  # +1
             word = raw_word.strip()
-            if (  # +2
-                len(word) >= min_word_length  # +4 (2 bool operator sequences * 2 for nesting)
+            if (  # +2 (nesting = 1)
+                len(word) >= min_word_length  # +2 (2 bool operator sequences)
                 and not (word.startswith('-') or word.endswith('-'))
             ):
-                if is_camel_case_word(word):  # +2
+                if is_camel_case_word(word):  # +3 (nesting=2)
                     raw_camelcase_words.append(word)
                 else:  # +1
                     processed_words.append(word.lower())
         return processed_words, raw_camelcase_words
-    """) == 11
+    """) == 9
 
 
 def test_break_and_continue():
@@ -142,9 +142,9 @@ def test_nested_functions():
         def foo(a):
             if a:  # +2
                 return 1
-        bar = lambda a: lambda b: b or 2  # +2 (+2 for or because lambda increases nesting)
+        bar = lambda a: lambda b: b or 2  # +1
         return bar(foo(a))(a)
-    """) == 4
+    """) == 3
 
 
 def test_ternary_operator():


### PR DESCRIPTION
Per Appendix B of the Cognitive Complexity specification, sequences of binary logical operators receive an increment (B1), not a nesting increment (B3). Remove the increment_by multiplier.

Closes #13. 