### PR TITLE
Remove penalty for break/continue

### DIFF
--- a/cognitive_complexity/utils/ast.py
+++ b/cognitive_complexity/utils/ast.py
@@ -87,6 +87,4 @@ def process_node_itself(
         inner_boolops_amount = len([n for n in ast.walk(node) if isinstance(n, ast.BoolOp)])
         base_complexity = inner_boolops_amount
         return increment_by, base_complexity, False
-    elif isinstance(node, (ast.Break, ast.Continue)):
-        return increment_by, max(1, increment_by), True
     return increment_by, 0, True

--- a/tests/test_cognitive_complexity.py
+++ b/tests/test_cognitive_complexity.py
@@ -130,10 +130,10 @@ def test_break_and_continue():
     def f(a):
         for a in range(10):  # +1
             if a % 2:  # +2
-                continue  # +2
+                continue
             if a == 8:  # +2
-                break  # +2
-    """) == 9
+                break
+    """) == 5
 
 
 def test_nested_functions():
@@ -197,12 +197,12 @@ def test_for_else_complexity():
     def f(a):
         for a in range(10):  # +1
             if a % 2:  # +2
-                continue  # +2
+                continue
             if a == 8:  # +2
-                break  # +2
+                break
         else:  # +1
             return 5
-    """) == 10
+    """) == 6
 
 
 def test_while_else_complexity():
@@ -211,10 +211,10 @@ def test_while_else_complexity():
         a = 0
         while a < 10:  # +1
             if a % 2:  # +2
-                continue  # +2
+                continue
             if a == 8:  # +2
-                break  # +2
+                break
             a += 1
         else:  # +1
             return 5
-    """) == 10
+    """) == 6


### PR DESCRIPTION
According to the Cognitive Complexity specification, only `break` and `continue` _to a label_ add a fundamental increment. Simple forms of these are easier to follow and "often make code much clearer", so these do not (of themselves) add any increment. (These keywords tend to appear in conditional constructs such as `if`, and the added complexity is already embodied in the structural increment for the conditional.)

Fix by removing the increment added in #2, but keeping (and adjusting) the tests.

Closes #14.