### PR TITLE
Fix overcounting for decorators

### DIFF
--- a/cognitive_complexity/api.py
+++ b/cognitive_complexity/api.py
@@ -2,11 +2,14 @@ import ast
 
 from cognitive_complexity.common_types import AnyFuncdef
 from cognitive_complexity.utils.ast import (
-    has_recursive_calls, process_child_nodes, process_node_itself,
+    has_recursive_calls, is_decorator, process_child_nodes, process_node_itself,
 )
 
 
 def get_cognitive_complexity(funcdef: AnyFuncdef) -> int:
+    if is_decorator(funcdef):
+        return get_cognitive_complexity(funcdef.body[0])  # type: ignore
+
     complexity = 0
     for node in funcdef.body:
         complexity += get_cognitive_complexity_for_node(node)

--- a/cognitive_complexity/utils/ast.py
+++ b/cognitive_complexity/utils/ast.py
@@ -16,6 +16,15 @@ def has_recursive_calls(funcdef: AnyFuncdef) -> bool:
     ])
 
 
+def is_decorator(funcdef: AnyFuncdef) -> bool:
+    return (
+        isinstance(funcdef, ast.FunctionDef)
+        and len(funcdef.body) == 2
+        and isinstance(funcdef.body[0], ast.FunctionDef)
+        and isinstance(funcdef.body[1], ast.Return)
+    )
+
+
 def process_child_nodes(
     node: ast.AST,
     increment_by: int,

--- a/tests/test_cognitive_complexity.py
+++ b/tests/test_cognitive_complexity.py
@@ -218,3 +218,39 @@ def test_while_else_complexity():
         else:  # +1
             return 5
     """) == 6
+
+
+def test_a_decorator_complexity():
+    assert get_code_snippet_compexity("""
+    def a_decorator(a, b):
+        def inner(func):  # nesting = 0
+            if condition:  # +1
+                print(b)
+            func()
+        return inner
+    """) == 1
+
+
+def test_not_a_decorator_complexity():
+    assert get_code_snippet_compexity("""
+    def not_a_decorator(a, b):
+        my_var = a*b
+        def inner(func):  # nesting = 1
+            if condition:  # +1 structure, +1 nesting
+                print(b)
+            func()
+        return inner
+    """) == 2
+
+
+def test_decorator_generator_complexity():
+    assert get_code_snippet_compexity("""
+    def decorator_generator(a):
+        def generator(func):
+            def decorator(func): # nesting = 0
+                if condition: # +1
+                    print(b)
+                return func()
+            return decorator
+        return generator
+    """) == 1


### PR DESCRIPTION
The Cognitive Complexity specification makes an exception for decorators (a function that contains only a nested function and a
return statement). In this case, there is no penalty for the nesting. To fix overcounting in this case, detect a decorator in
api.get_cognitive_complexity() as this is where the top-level function is handled.

Closes #4.